### PR TITLE
Add working interpreter

### DIFF
--- a/LLMLang_LLM_User_Guide.md
+++ b/LLMLang_LLM_User_Guide.md
@@ -1,0 +1,85 @@
+# LLMLang Guide for LLMs
+
+This document summarizes how to use the minimal implementation of **LLMLang** included in this repository. It is intended to be provided to an LLM so it knows the language syntax, builtins, and overall execution flow.
+
+## Overview
+
+LLMLang (also referred to as *LLM-IR*) is a compact, expression-oriented language designed for efficient token usage. It compiles to LLVM IR and supports a Rust-like ownership model, arrays, conditionals, function calls, and simple concurrency primitives.
+
+The repository includes a lexer, parser, borrow checker stub, scheduler, runtime skeleton, and a basic interpreter capable of evaluating expressions.
+
+## Design Principles
+
+1. **Token Efficiency** – tersely symbolic syntax.
+2. **Logic Density** – expression-based structure.
+3. **Execution Efficiency** – direct LLVM IR backend.
+4. **Memory Safety** – Rust-style ownership/borrowing model.
+5. **Concurrency** – actor and shared-memory support.
+6. **Interoperability** – FFI for C/C++/Rust libraries.
+
+See `llmir_language_design_goals.md` for the full list.
+
+## Core Syntax
+
+The grammar is expression-based (see `llmir_grammar_spec.md`). Key forms include:
+
+```
+Program       ::= Expression*
+Expression    ::= Literal
+                 | Identifier
+                 | Assignment
+                 | BinaryOp
+                 | ArrayExpr
+                 | IfExpr
+                 | FunctionCall
+
+Assignment    ::= Identifier ← Expression
+BinaryOp      ::= Expression Operator Expression
+ArrayExpr     ::= '[' Expression* ']'
+IfExpr        ::= 'if' Expression 'then' Expression 'else' Expression
+FunctionCall  ::= Identifier '(' Expression* ')'
+```
+
+Literals include numbers, strings, and booleans (`true`/`false`). Operators cover arithmetic (`+ - * /`) and comparisons (`== != < > <= >=`).
+
+## Interpreter
+
+The interpreter evaluates parsed AST nodes. Built‑in functions include:
+
+- `add(a, b)` – addition
+- `sub(a, b)` – subtraction
+- `mul(a, b)` – multiplication
+- `div(a, b)` – division
+- `sum(array)` – sum of array elements
+- `print(value)` – output to console
+
+The interpreter stores variables in a simple dictionary and supports assignments and `if` expressions. Arrays are evaluated recursively.
+
+Example usage from Python:
+
+```python
+from llmir import Interpreter
+
+interp = Interpreter()
+result = interp.eval("x ← 2 add(x, 3)")
+print(result)  # -> [2, 5]
+```
+
+Each call to `eval` returns a list of the results of the top-level expressions.
+
+## Execution Pipeline
+
+1. **Lexer** – converts source text to tokens.
+2. **Parser** – creates AST nodes from tokens.
+3. **Borrow Checker** – stub that validates ownership rules (no-op).
+4. **Interpreter/Compiler** – evaluate expressions or emit LLVM IR.
+5. **Scheduler/Runtime** – placeholders for concurrency and runtime services.
+
+## Extending the Language
+
+Modules can be loaded via `$import` (lexer recognizes this token). The compiler stub illustrates how AST nodes map to LLVM IR. The scheduler and runtime are minimal and meant for experimentation.
+
+## Running Tests
+
+Unit tests reside under `tests/` and can be executed with `pytest -q`.
+

--- a/llmir/__init__.py
+++ b/llmir/__init__.py
@@ -1,0 +1,19 @@
+
+from .lexer import Lexer
+from .parser import Parser
+from .borrow_checker import BorrowChecker
+from .module_loader import ModuleLoader
+from .scheduler import Scheduler
+from .runtime import Runtime
+from .interpreter import Interpreter
+
+__all__ = [
+    'Lexer',
+    'Parser',
+    'BorrowChecker',
+    'ModuleLoader',
+    'Scheduler',
+    'Runtime',
+    'Interpreter',
+]
+

--- a/llmir/ast.py
+++ b/llmir/ast.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+class Expr:
+    pass
+
+
+@dataclass
+class Number(Expr):
+    value: float
+
+
+@dataclass
+class StringLiteral(Expr):
+    value: str
+
+
+@dataclass
+class Boolean(Expr):
+    value: bool
+
+
+@dataclass
+class Identifier(Expr):
+    name: str
+
+
+@dataclass
+class BinaryOp(Expr):
+    left: Expr
+    op: str
+    right: Expr
+
+
+@dataclass
+class Call(Expr):
+    func: Identifier
+    args: List[Expr]
+
+
+@dataclass
+class ArrayExpr(Expr):
+    elements: List[Expr]
+
+
+@dataclass
+class Assignment(Expr):
+    target: Identifier
+    value: Expr
+
+
+@dataclass
+class IfExpr(Expr):
+    cond: Expr
+    then_branch: Expr
+    else_branch: Expr
+

--- a/llmir/borrow_checker.py
+++ b/llmir/borrow_checker.py
@@ -1,0 +1,6 @@
+class BorrowChecker:
+    """Very simple borrow checker stub."""
+
+    def check(self, exprs):
+        for _ in exprs:
+            pass  # placeholder for borrow checking logic

--- a/llmir/compiler.py
+++ b/llmir/compiler.py
@@ -1,0 +1,58 @@
+"""Minimal compiler stub that converts AST to pseudo LLVM IR."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .ast import (
+    ArrayExpr,
+    Assignment,
+    BinaryOp,
+    Boolean,
+    Call,
+    Expr,
+    Identifier,
+    IfExpr,
+    Number,
+    StringLiteral,
+)
+
+
+class Compiler:
+    def compile(self, exprs: List[Expr]) -> str:
+        lines = ["; ModuleID = 'llmir'"]
+        for i, expr in enumerate(exprs):
+            lines.append(self.emit_expr(expr, i))
+        return "\n".join(lines)
+
+    def emit_expr(self, expr: Expr, idx: int) -> str:
+        if isinstance(expr, Number):
+            return f"%{idx} = add i32 0, {expr.value}"
+        if isinstance(expr, Boolean):
+            val = 1 if expr.value else 0
+            return f"%{idx} = add i1 0, {val}"
+        if isinstance(expr, StringLiteral):
+            return f"; string \"{expr.value}\""
+        if isinstance(expr, Identifier):
+            return f"; identifier {expr.name}"
+        if isinstance(expr, BinaryOp):
+            left = self.emit_expr(expr.left, idx)
+            right = self.emit_expr(expr.right, idx + 1)
+            op_map = {'+': 'add', '-': 'sub', '*': 'mul', '/': 'sdiv'}
+            op = op_map.get(expr.op, 'add')
+            return f"%{idx} = {op} i32 %{idx}, %{idx + 1}"
+        if isinstance(expr, Assignment):
+            value = self.emit_expr(expr.value, idx)
+            return value + f"\n; assign {expr.target.name}"
+        if isinstance(expr, ArrayExpr):
+            parts = [self.emit_expr(e, idx + i) for i, e in enumerate(expr.elements)]
+            return "\n".join(parts)
+        if isinstance(expr, Call):
+            args = [self.emit_expr(a, idx + i) for i, a in enumerate(expr.args)]
+            return "\n".join(args) + f"\n; call {expr.func.name}"
+        if isinstance(expr, IfExpr):
+            cond = self.emit_expr(expr.cond, idx)
+            then_ir = self.emit_expr(expr.then_branch, idx + 1)
+            else_ir = self.emit_expr(expr.else_branch, idx + 2)
+            return "\n".join([cond, then_ir, else_ir, "; if expr"])
+        return f"; unknown expr"

--- a/llmir/ffi.py
+++ b/llmir/ffi.py
@@ -1,0 +1,5 @@
+class FFI:
+    """Placeholder for foreign function interface."""
+
+    def import_library(self, name: str) -> None:
+        pass

--- a/llmir/interpreter.py
+++ b/llmir/interpreter.py
@@ -1,0 +1,97 @@
+"""Simple interpreter orchestrating lexer, parser, and evaluator."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Callable
+
+from .parser import Parser
+from .borrow_checker import BorrowChecker
+from .ast import (
+    ArrayExpr,
+    Assignment,
+    BinaryOp,
+    Boolean,
+    Call,
+    Expr,
+    Identifier,
+    IfExpr,
+    Number,
+    StringLiteral,
+)
+
+
+class Interpreter:
+    def __init__(self) -> None:
+        self.borrow_checker = BorrowChecker()
+        self.env: Dict[str, Any] = {}
+        self.builtins: Dict[str, Callable[..., Any]] = {
+            "add": lambda a, b: a + b,
+            "sub": lambda a, b: a - b,
+            "mul": lambda a, b: a * b,
+            "div": lambda a, b: a / b,
+            "sum": lambda arr: sum(arr),
+            "print": print,
+        }
+
+    def eval(self, source: str) -> List[Any]:
+        parser = Parser(source)
+        exprs = parser.parse()
+        # Borrow check (no-op placeholder)
+        self.borrow_checker.check(exprs)
+        results: List[Any] = []
+        for expr in exprs:
+            results.append(self.eval_expr(expr))
+        return results
+
+    def eval_expr(self, expr: Expr) -> Any:
+        if isinstance(expr, Number):
+            return expr.value
+        if isinstance(expr, StringLiteral):
+            return expr.value
+        if isinstance(expr, Boolean):
+            return expr.value
+        if isinstance(expr, Identifier):
+            if expr.name in self.env:
+                return self.env[expr.name]
+            raise NameError(expr.name)
+        if isinstance(expr, ArrayExpr):
+            return [self.eval_expr(e) for e in expr.elements]
+        if isinstance(expr, Assignment):
+            value = self.eval_expr(expr.value)
+            self.env[expr.target.name] = value
+            return value
+        if isinstance(expr, BinaryOp):
+            left = self.eval_expr(expr.left)
+            right = self.eval_expr(expr.right)
+            if expr.op == '+':
+                return left + right
+            if expr.op == '-':
+                return left - right
+            if expr.op == '*':
+                return left * right
+            if expr.op == '/':
+                return left / right
+            if expr.op == '==':
+                return left == right
+            if expr.op == '!=':
+                return left != right
+            if expr.op == '<':
+                return left < right
+            if expr.op == '>':
+                return left > right
+            if expr.op == '<=':
+                return left <= right
+            if expr.op == '>=':
+                return left >= right
+            raise ValueError(f"Unknown operator {expr.op}")
+        if isinstance(expr, IfExpr):
+            cond = self.eval_expr(expr.cond)
+            return self.eval_expr(expr.then_branch if cond else expr.else_branch)
+        if isinstance(expr, Call):
+            func_name = expr.func.name
+            args = [self.eval_expr(a) for a in expr.args]
+            if func_name in self.builtins:
+                return self.builtins[func_name](*args)
+            raise NameError(f"Unknown function {func_name}")
+        raise TypeError(f"Unhandled expression type {type(expr)}")
+

--- a/llmir/lexer.py
+++ b/llmir/lexer.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .token import Token, TokenType
+
+
+@dataclass
+class Lexer:
+    source: str
+
+    def tokenize(self) -> List[Token]:
+        tokens: List[Token] = []
+        i = 0
+        length = len(self.source)
+        while i < length:
+            ch = self.source[i]
+            if ch.isspace():
+                i += 1
+                continue
+            if ch.isdigit():
+                start = i
+                has_dot = False
+                while i < length and (self.source[i].isdigit() or (self.source[i] == '.' and not has_dot)):
+                    if self.source[i] == '.':
+                        has_dot = True
+                    i += 1
+                tokens.append(Token(TokenType.NUMBER, self.source[start:i], start))
+                continue
+            if ch.isalpha() or ch == '_' or ch == '$':
+                start = i
+                while i < length and (self.source[i].isalnum() or self.source[i] in '_$'):
+                    i += 1
+                ident = self.source[start:i]
+                if ident == 'if':
+                    tokens.append(Token(TokenType.IF, ident, start))
+                elif ident == 'then':
+                    tokens.append(Token(TokenType.THEN, ident, start))
+                elif ident == 'else':
+                    tokens.append(Token(TokenType.ELSE, ident, start))
+                elif ident == 'true' or ident == 'false':
+                    tokens.append(Token(TokenType.BOOLEAN, ident, start))
+                elif ident == '$import':
+                    tokens.append(Token(TokenType.IMPORT, ident, start))
+                else:
+                    tokens.append(Token(TokenType.IDENT, ident, start))
+                continue
+            if ch == '(':
+                tokens.append(Token(TokenType.LPAREN, ch, i))
+                i += 1
+                continue
+            if ch == ')':
+                tokens.append(Token(TokenType.RPAREN, ch, i))
+                i += 1
+                continue
+            if ch == '[':
+                tokens.append(Token(TokenType.LBRACKET, ch, i))
+                i += 1
+                continue
+            if ch == ']':
+                tokens.append(Token(TokenType.RBRACKET, ch, i))
+                i += 1
+                continue
+            if ch == ',':
+                tokens.append(Token(TokenType.COMMA, ch, i))
+                i += 1
+                continue
+            if ch == '←':
+                tokens.append(Token(TokenType.ASSIGN, ch, i))
+                i += 1
+                continue
+            if ch in '+-*/^%<>=!':
+                start = i
+                i += 1
+                if i < length and self.source[i] == '=':
+                    op = self.source[start:i+1]
+                    tokens.append(Token(TokenType.OPERATOR, op, start))
+                    i += 1
+                else:
+                    tokens.append(Token(TokenType.OPERATOR, ch, start))
+                continue
+            if ch == '"':
+                start = i
+                i += 1
+                while i < length and self.source[i] != '"':
+                    i += 1
+                value = self.source[start + 1:i]
+                i += 1
+                tokens.append(Token(TokenType.STRING, value, start))
+                continue
+            # Unknown character
+            i += 1
+        tokens.append(Token(TokenType.EOF, pos=length))
+        return tokens

--- a/llmir/module_loader.py
+++ b/llmir/module_loader.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from .parser import Parser
+from .ast import Expr
+
+
+class ModuleLoader:
+    """Load llmir modules from disk."""
+
+    def load_module(self, path: str) -> List[Expr]:
+        with open(path, "r", encoding="utf-8") as f:
+            source = f.read()
+        parser = Parser(source)
+        return parser.parse()

--- a/llmir/parser.py
+++ b/llmir/parser.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import List
+
+from .ast import (
+    ArrayExpr,
+    Assignment,
+    BinaryOp,
+    Boolean,
+    Call,
+    Expr,
+    Identifier,
+    IfExpr,
+    Number,
+    StringLiteral,
+)
+from .lexer import Lexer
+from .token import Token, TokenType
+
+
+class Parser:
+    def __init__(self, source: str) -> None:
+        self.lexer = Lexer(source)
+        self.tokens = self.lexer.tokenize()
+        self.pos = 0
+
+    def peek(self) -> Token:
+        return self.tokens[self.pos]
+
+    def consume(self) -> Token:
+        tok = self.tokens[self.pos]
+        self.pos += 1
+        return tok
+
+    def parse_number(self) -> Number:
+        tok = self.consume()
+        assert tok.type == TokenType.NUMBER
+        return Number(float(tok.value))
+
+    def parse_string(self) -> StringLiteral:
+        tok = self.consume()
+        assert tok.type == TokenType.STRING
+        return StringLiteral(tok.value)
+
+    def parse_boolean(self) -> Boolean:
+        tok = self.consume()
+        assert tok.type == TokenType.BOOLEAN
+        return Boolean(tok.value == "true")
+
+    def parse_identifier(self) -> Identifier:
+        tok = self.consume()
+        assert tok.type == TokenType.IDENT
+        return Identifier(tok.value)
+
+    def parse_array(self) -> ArrayExpr:
+        self.consume()  # [
+        elements: List[Expr] = []
+        while self.peek().type != TokenType.RBRACKET:
+            elements.append(self.parse_expression())
+            if self.peek().type == TokenType.COMMA:
+                self.consume()
+        self.consume()  # ]
+        return ArrayExpr(elements)
+
+    def parse_call(self, ident: Identifier) -> Call:
+        self.consume()  # (
+        args: List[Expr] = []
+        while self.peek().type != TokenType.RPAREN:
+            args.append(self.parse_expression())
+            if self.peek().type == TokenType.COMMA:
+                self.consume()
+        self.consume()
+        return Call(ident, args)
+
+    def parse_if_expr(self) -> IfExpr:
+        self.consume()  # if
+        cond = self.parse_expression()
+        self.consume()  # then
+        then_branch = self.parse_expression()
+        self.consume()  # else
+        else_branch = self.parse_expression()
+        return IfExpr(cond, then_branch, else_branch)
+
+    def parse_primary(self) -> Expr:
+        tok = self.peek()
+        if tok.type == TokenType.NUMBER:
+            return self.parse_number()
+        if tok.type == TokenType.STRING:
+            return self.parse_string()
+        if tok.type == TokenType.BOOLEAN:
+            return self.parse_boolean()
+        if tok.type == TokenType.IDENT:
+            ident = self.parse_identifier()
+            if self.peek().type == TokenType.LPAREN:
+                return self.parse_call(ident)
+            return ident
+        if tok.type == TokenType.LBRACKET:
+            return self.parse_array()
+        if tok.type == TokenType.LPAREN:
+            self.consume()
+            expr = self.parse_expression()
+            self.consume()  # RPAREN
+            return expr
+        if tok.type == TokenType.IF:
+            return self.parse_if_expr()
+        raise SyntaxError(f"Unexpected token {tok}")
+
+    def parse_expression(self) -> Expr:
+        expr = self.parse_primary()
+        if isinstance(expr, Identifier) and self.peek().type == TokenType.ASSIGN:
+            self.consume()
+            value = self.parse_expression()
+            return Assignment(expr, value)
+        while self.peek().type == TokenType.OPERATOR:
+            op = self.consume().value
+            right = self.parse_primary()
+            expr = BinaryOp(expr, op, right)
+        return expr
+
+    def parse(self) -> List[Expr]:
+        exprs: List[Expr] = []
+        while self.peek().type != TokenType.EOF:
+            exprs.append(self.parse_expression())
+        return exprs

--- a/llmir/runtime.py
+++ b/llmir/runtime.py
@@ -1,0 +1,8 @@
+class Runtime:
+    """Placeholder runtime providing minimal services."""
+
+    def __init__(self) -> None:
+        self.ffi = None
+
+    def set_ffi(self, ffi) -> None:
+        self.ffi = ffi

--- a/llmir/scheduler.py
+++ b/llmir/scheduler.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from threading import Thread
+from typing import Callable, List
+
+
+class Scheduler:
+    """Very simple scheduler for running tasks sequentially."""
+
+    def __init__(self) -> None:
+        self.tasks: List[Callable[[], None]] = []
+
+    def schedule(self, task: Callable[[], None]) -> None:
+        self.tasks.append(task)
+
+    def run(self) -> None:
+        for task in self.tasks:
+            t = Thread(target=task)
+            t.start()
+            t.join()

--- a/llmir/token.py
+++ b/llmir/token.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Optional
+
+
+class TokenType(Enum):
+    NUMBER = auto()
+    STRING = auto()
+    IDENT = auto()
+    OPERATOR = auto()
+    LBRACKET = auto()
+    RBRACKET = auto()
+    LPAREN = auto()
+    RPAREN = auto()
+    ASSIGN = auto()
+    COMMA = auto()
+    BOOLEAN = auto()
+    IMPORT = auto()
+    IF = auto()
+    THEN = auto()
+    ELSE = auto()
+    EOF = auto()
+@dataclass
+class Token:
+    type: TokenType
+    value: Optional[str] = None
+    pos: int = 0
+
+    def __repr__(self) -> str:
+        return f"Token({self.type}, {self.value})"

--- a/llmir_progress_tracker.md
+++ b/llmir_progress_tracker.md
@@ -36,10 +36,12 @@
    - Lexer, parser, IR builder
    - Borrow checker, scheduler, backend
 
-9. **Interpreter Implementation** 🚧
-   - Work started module-by-module
-   - Lexer/parser in progress
+9. **Interpreter Implementation** ✅
+   - Lexer/parser expanded with arrays, if/else, strings
+   - Borrow checker and scheduler stubs added
+   - Module loader and runtime skeletons
+   - Basic interpreter evaluating expressions
 
-10. **Compiler Stub Outline** 🕓
-   - Next step: emit to LLVM IR for basic ops
+10. **Compiler Stub Outline** ✅
+   - Emits placeholder LLVM IR for core expressions
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from llmir.interpreter import Interpreter
+
+
+class TestInterpreter(unittest.TestCase):
+    def test_basic_arithmetic(self):
+        interp = Interpreter()
+        results = interp.eval("1+2")
+        self.assertEqual(results, [3])
+
+    def test_assignment_and_reference(self):
+        interp = Interpreter()
+        results = interp.eval("x ← 5 x + 1")
+        self.assertEqual(results, [5, 6])
+
+    def test_if_and_sum(self):
+        interp = Interpreter()
+        results = interp.eval("if false then 1 else sum([1,2,3])")
+        self.assertEqual(results, [6])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from llmir.lexer import Lexer
+from llmir.token import TokenType
+
+
+class TestLexer(unittest.TestCase):
+    def test_numbers_and_identifiers(self):
+        lex = Lexer("foo 123")
+        tokens = lex.tokenize()
+        self.assertEqual(tokens[0].type, TokenType.IDENT)
+        self.assertEqual(tokens[0].value, "foo")
+        self.assertEqual(tokens[1].type, TokenType.NUMBER)
+        self.assertEqual(tokens[1].value, "123")
+        self.assertEqual(tokens[-1].type, TokenType.EOF)
+
+    def test_strings_and_booleans(self):
+        lex = Lexer('"hi" true false')
+        tokens = lex.tokenize()
+        self.assertEqual(tokens[0].type, TokenType.STRING)
+        self.assertEqual(tokens[0].value, "hi")
+        self.assertEqual(tokens[1].type, TokenType.BOOLEAN)
+        self.assertEqual(tokens[1].value, "true")
+        self.assertEqual(tokens[2].type, TokenType.BOOLEAN)
+        self.assertEqual(tokens[2].value, "false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from llmir.parser import Parser
+from llmir.ast import ArrayExpr, Assignment, BinaryOp, Boolean, IfExpr, Number
+
+
+class TestParser(unittest.TestCase):
+    def test_simple_expression(self):
+        parser = Parser("1+2")
+        exprs = parser.parse()
+        self.assertEqual(len(exprs), 1)
+        expr = exprs[0]
+        self.assertIsInstance(expr, BinaryOp)
+        self.assertIsInstance(expr.left, Number)
+        self.assertEqual(expr.left.value, 1.0)
+        self.assertIsInstance(expr.right, Number)
+        self.assertEqual(expr.right.value, 2.0)
+        self.assertEqual(expr.op, "+")
+
+    def test_if_and_array(self):
+        parser = Parser("if true then [1,2] else [3]")
+        exprs = parser.parse()
+        self.assertEqual(len(exprs), 1)
+        expr = exprs[0]
+        self.assertIsInstance(expr, IfExpr)
+        self.assertIsInstance(expr.cond, Boolean)
+        self.assertTrue(expr.cond.value)
+        self.assertIsInstance(expr.then_branch, ArrayExpr)
+        self.assertEqual(len(expr.then_branch.elements), 2)
+        self.assertIsInstance(expr.else_branch, ArrayExpr)
+        self.assertEqual(len(expr.else_branch.elements), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose `Interpreter` in package exports
- implement a basic interpreter that evaluates AST expressions
- add tests covering arithmetic, assignments, and `if`/`sum`
- update progress tracker with interpreter details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b952ea04832d95bd8647e6b72b6a