### PR TITLE
Add hello world example with interpreter

### DIFF
--- a/llmir/__init__.py
+++ b/llmir/__init__.py
@@ -1,0 +1,5 @@
+from .lexer import Lexer
+from .parser import Parser
+from .compiler import Compiler
+from .interpreter import Interpreter
+

--- a/llmir/ast.py
+++ b/llmir/ast.py
@@ -28,3 +28,8 @@ class Call(Expr):
     func: Identifier
     args: List[Expr]
 
+
+@dataclass
+class StringLiteral(Expr):
+    value: str
+

--- a/llmir/interpreter.py
+++ b/llmir/interpreter.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from .ast import BinaryOp, Call, Expr, Identifier, Number, StringLiteral
+
+
+class Interpreter:
+    """Very small interpreter for demonstration purposes."""
+
+    def eval(self, exprs: List[Expr]) -> Any:
+        result: Any = None
+        for expr in exprs:
+            result = self.eval_expr(expr)
+        return result
+
+    def eval_expr(self, expr: Expr) -> Any:
+        if isinstance(expr, Number):
+            return int(expr.value)
+        if isinstance(expr, StringLiteral):
+            return expr.value
+        if isinstance(expr, BinaryOp):
+            left = self.eval_expr(expr.left)
+            right = self.eval_expr(expr.right)
+            if expr.op == '+':
+                return left + right
+            if expr.op == '-':
+                return left - right
+            if expr.op == '*':
+                return left * right
+            if expr.op == '/':
+                return left // right
+            raise NotImplementedError(f"Operator {expr.op}")
+        if isinstance(expr, Call):
+            func_name = expr.func.name
+            args = [self.eval_expr(arg) for arg in expr.args]
+            if func_name == 'print':
+                print(*args)
+                return None
+            raise NotImplementedError(f"Unknown function {func_name}")
+        if isinstance(expr, Identifier):
+            raise NotImplementedError("Variables not supported")
+        raise NotImplementedError(f"Unknown expression {expr}")

--- a/llmir/parser.py
+++ b/llmir/parser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from .ast import BinaryOp, Call, Expr, Identifier, Number
+from .ast import BinaryOp, Call, Expr, Identifier, Number, StringLiteral
 from .lexer import Lexer
 from .token import Token, TokenType
 
@@ -31,12 +31,42 @@ class Parser:
         assert tok.type == TokenType.IDENT
         return Identifier(tok.value)
 
+    def parse_string(self) -> StringLiteral:
+        tok = self.consume()
+        assert tok.type == TokenType.STRING
+        value = tok.value[1:-1]
+        return StringLiteral(value)
+
     def parse_primary(self) -> Expr:
         tok = self.peek()
         if tok.type == TokenType.NUMBER:
             return self.parse_number()
+        if tok.type == TokenType.STRING:
+            return self.parse_string()
         if tok.type == TokenType.IDENT:
-            return self.parse_identifier()
+            ident = self.parse_identifier()
+            if self.peek().type == TokenType.LPAREN:
+                self.consume()  # (
+                args: List[Expr] = []
+                if self.peek().type != TokenType.RPAREN:
+                    while True:
+                        args.append(self.parse_expression())
+                        if self.peek().type == TokenType.COMMA:
+                            self.consume()
+                        else:
+                            break
+                if self.peek().type != TokenType.RPAREN:
+                    raise SyntaxError("Expected ')'")
+                self.consume()
+                return Call(ident, args)
+            return ident
+        if tok.type == TokenType.LPAREN:
+            self.consume()
+            expr = self.parse_expression()
+            if self.peek().type != TokenType.RPAREN:
+                raise SyntaxError("Expected ')'")
+            self.consume()
+            return expr
         raise SyntaxError(f"Unexpected token {tok}")
 
     def parse_expression(self) -> Expr:

--- a/run_hello.py
+++ b/run_hello.py
@@ -1,0 +1,8 @@
+from llmir.parser import Parser
+from llmir.interpreter import Interpreter
+
+code = 'print("Hello, world!")'
+parser = Parser(code)
+exprs = parser.parse()
+Interpreter().eval(exprs)
+


### PR DESCRIPTION
## Summary
- add a minimal interpreter with built-in `print`
- extend AST with `StringLiteral`
- update parser to support strings and simple function calls
- expose interpreter in `llmir` package
- add `run_hello.py` example demonstrating `print("Hello, world!")`

## Testing
- `pytest -q`
- `python run_hello.py`


------
https://chatgpt.com/codex/tasks/task_e_6855fd2bf04c832dad561f81e86b05bd